### PR TITLE
Hotfix - Model Serializers

### DIFF
--- a/project/imdb/urls.py
+++ b/project/imdb/urls.py
@@ -4,4 +4,12 @@ from . import views
 
 urlpatterns = [
     path('users', views.users_list),
+    path('users/<int:pk>', views.user_detail),
+    path('users/create', views.user_create),
+    path('users/<int:pk>/update', views.user_update),
+    path('users/<int:pk>/delete', views.user_delete),
+    path('users/<int:pk>/movies', views.user_movies_list),
+    path('movies', views.movies_list),
+    path('movies/<query>', views.movies_search),
+    path('lists', views.all_user_movies_list),
 ]

--- a/project/imdb/urls.py
+++ b/project/imdb/urls.py
@@ -11,5 +11,4 @@ urlpatterns = [
     path('users/<int:pk>/movies', views.user_movies_list),
     path('movies', views.movies_list),
     path('movies/<query>', views.movies_search),
-    path('lists', views.all_user_movies_list),
 ]

--- a/project/imdb/views.py
+++ b/project/imdb/views.py
@@ -14,12 +14,14 @@ def users_list(request):
         serializer = UserSerializer(users, many=True)
         return Response(serializer.data)
 
+
 @api_view(['GET'])
 def user_detail(request, pk):
     if request.method == 'GET':
         user = User.objects.get(pk=pk)
         serializer = UserSerializer(user)
         return Response(serializer.data)
+
 
 @api_view(['POST'])
 def user_create(request):
@@ -30,7 +32,8 @@ def user_create(request):
             return Response(serializer.data, status=status.HTTP_201_CREATED)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-@api_view(['PUT']) # TODO: Authorization process
+
+@api_view(['PUT'])  # TODO: Authorization process
 def user_update(request, pk):
     if request.method == 'PUT':
         user = User.objects.get(pk=pk)
@@ -40,28 +43,23 @@ def user_update(request, pk):
             return Response(serializer.data)
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
-@api_view(['DELETE']) # TODO: Authorization process
+
+@api_view(['DELETE'])  # TODO: Authorization process
 def user_delete(request, pk):
     if request.method == 'DELETE':
         user = User.objects.get(pk=pk)
         user.delete()
         return Response(status=status.HTTP_204_NO_CONTENT)
 
+
 @api_view(['GET'])
 def user_movies_list(request, pk):
     if request.method == 'GET':
         user = User.objects.get(pk=pk)
-        movies = user.film_lists
-        list_ids = UserMoviesList.objects.get(pk=movies.id)
-        serializer = UserMoviesListSerializer(list_ids, many=True)
-        return Response(serializer.data)
-
-@api_view(['GET'])
-def all_user_movies_list(request):
-    if request.method == 'GET':
-        movies = UserMoviesList.objects.all()
+        movies = UserMoviesList.objects.filter(user_created=user)
         serializer = UserMoviesListSerializer(movies, many=True)
         return Response(serializer.data)
+
 
 @api_view(['GET'])
 def movies_list(request):
@@ -70,10 +68,10 @@ def movies_list(request):
         serializer = MovieSerializer(movies, many=True)
         return Response(serializer.data)
 
+
 @api_view(['GET'])
 def movies_search(request, query):
     if request.method == 'GET':
         movies = Movie.objects.filter(title__icontains=query)
         serializer = MovieSerializer(movies, many=True)
         return Response(serializer.data)
-

--- a/project/imdb/views.py
+++ b/project/imdb/views.py
@@ -2,8 +2,8 @@ from django.http import HttpResponse
 from rest_framework import status
 from rest_framework.decorators import api_view
 from rest_framework.response import Response
-from .models import User
-from .serializers import UserSerializer
+from .models import User, Movie, UserMoviesList
+from .serializers import UserSerializer, UserMoviesListSerializer, MovieSerializer, PeopleSerializer
 from django.core.exceptions import PermissionDenied
 
 
@@ -12,5 +12,68 @@ def users_list(request):
     if request.method == 'GET':
         users = User.objects.all()
         serializer = UserSerializer(users, many=True)
+        return Response(serializer.data)
+
+@api_view(['GET'])
+def user_detail(request, pk):
+    if request.method == 'GET':
+        user = User.objects.get(pk=pk)
+        serializer = UserSerializer(user)
+        return Response(serializer.data)
+
+@api_view(['POST'])
+def user_create(request):
+    if request.method == 'POST':
+        serializer = UserSerializer(data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data, status=status.HTTP_201_CREATED)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+@api_view(['PUT']) # TODO: Authorization process
+def user_update(request, pk):
+    if request.method == 'PUT':
+        user = User.objects.get(pk=pk)
+        serializer = UserSerializer(user, data=request.data)
+        if serializer.is_valid():
+            serializer.save()
+            return Response(serializer.data)
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+@api_view(['DELETE']) # TODO: Authorization process
+def user_delete(request, pk):
+    if request.method == 'DELETE':
+        user = User.objects.get(pk=pk)
+        user.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+@api_view(['GET'])
+def user_movies_list(request, pk):
+    if request.method == 'GET':
+        user = User.objects.get(pk=pk)
+        movies = user.film_lists
+        list_ids = UserMoviesList.objects.get(pk=movies.id)
+        serializer = UserMoviesListSerializer(list_ids, many=True)
+        return Response(serializer.data)
+
+@api_view(['GET'])
+def all_user_movies_list(request):
+    if request.method == 'GET':
+        movies = UserMoviesList.objects.all()
+        serializer = UserMoviesListSerializer(movies, many=True)
+        return Response(serializer.data)
+
+@api_view(['GET'])
+def movies_list(request):
+    if request.method == 'GET':
+        movies = Movie.objects.all()
+        serializer = MovieSerializer(movies, many=True)
+        return Response(serializer.data)
+
+@api_view(['GET'])
+def movies_search(request, query):
+    if request.method == 'GET':
+        movies = Movie.objects.filter(title__icontains=query)
+        serializer = MovieSerializer(movies, many=True)
         return Response(serializer.data)
 


### PR DESCRIPTION
Rapid hotfix of incorrectly working model serializers and merge of new urls to use.

This PR adds URL paths for getting specific user details, creating/updating/deleting users, view a specific users' movie lists, viewing all movies available, and querying a specific movie by title.

In addition, views have been added, with GET/POST/PUT/DELETE methods for all of the relevant mentioned above views.

Everything should work now, although in the future we will need to add authentication for updating, modifying, or deleting a user (i.e, only an admin or the user who originally created the data can make changes) - This can be done by checking if request.user == item.user or something like this.